### PR TITLE
Allow [[/div_]] to end blocks

### DIFF
--- a/lib/Text_Wiki/Text/Wiki/Parse/Default/Div.php
+++ b/lib/Text_Wiki/Text/Wiki/Parse/Default/Div.php
@@ -1,53 +1,53 @@
 <?php
 
 /**
- * 
- * Parses divs.
- * 
- * @category Text
- * 
- * @package Text_Wiki
- * 
- * @author Michal Frackowiak
- * 
- * @license LGPL
- * 
- * @version $Id$
- * 
- */
-
-/**
- * 
+ *
  * Parses divs.
  *
  * @category Text
- * 
+ *
  * @package Text_Wiki
- * 
+ *
  * @author Michal Frackowiak
- * 
+ *
+ * @license LGPL
+ *
+ * @version $Id$
+ *
+ */
+
+/**
+ *
+ * Parses divs.
+ *
+ * @category Text
+ *
+ * @package Text_Wiki
+ *
+ * @author Michal Frackowiak
+ *
  */
 
 class Text_Wiki_Parse_Div extends Text_Wiki_Parse {
 
     /**
-     * 
+     *
      * The regular expression used to find source text matching this
      * rule.
-     * 
+     *
      * @access public
-     * 
+     *
      * @var string
-     * 
+     *
      */
     public $regex = '/(\n)?\[\[div(\s.*?)?\]\] *\n((?:(?R)|.)*?)\[\[\/div\]\] */msi';
 
     /**
-     * 
+     *
      * Generates a token entry for the matched text.  Token options are:
-     * 
+     *
      * 'text' => The full matched text, not including the <code></code> tags.
-     * 
+     *
      * @access public
      *
      * @param array &$matches The array of matches from parse().
@@ -56,10 +56,10 @@ class Text_Wiki_Parse_Div extends Text_Wiki_Parse {
      * the source text.
      *
      */
-    
+
     function process(&$matches) {
         $content = $matches[3];
-        
+
         $attr = $this->getAttrs(trim($matches[2]));
         $args = array();
         if ($attr['class']) {
@@ -72,14 +72,14 @@ class Text_Wiki_Parse_Div extends Text_Wiki_Parse {
             $args['style'] = $style;
         }
         $options = array('args' => $args, 'type' => 'start');
-        
-        $start = $this->wiki->addToken($this->rule, $options);       
+
+        $start = $this->wiki->addToken($this->rule, $options);
 
         $end = $this->wiki->addToken($this->rule, array(
             'type' => 'end'));
-        
+
         return $matches[1] . $matches[1] . $start . "\n\n" . $content . "\n\n" . $end;
-    
+
     }
 
     function parse() {

--- a/lib/Text_Wiki/Text/Wiki/Parse/Default/Div.php
+++ b/lib/Text_Wiki/Text/Wiki/Parse/Default/Div.php
@@ -40,7 +40,7 @@ class Text_Wiki_Parse_Div extends Text_Wiki_Parse {
      * @var string
      *
      */
-    public $regex = '/(\n)?\[\[div(\s.*?)?\]\] *\n((?:(?R)|.)*?)\[\[\/div\]\] */msi';
+    public $regex = '/(\n)?\[\[div(\s.*?)?\]\] *\n((?:(?R)|.)*?)\[\[\/div_?\]\] */msi';
 
     /**
      *


### PR DESCRIPTION
Since `[[div_]]` is a modified wikidot div that is syntactically permissible, `[[/div_]]` should be permitted as well.