### PR TITLE
Use gender neutral pronouns

### DIFF
--- a/php/actions/ManageSiteBlockAction.php
+++ b/php/actions/ManageSiteBlockAction.php
@@ -58,7 +58,7 @@ class ManageSiteBlockAction extends SmartyAction {
 		$mem = MemberPeer::instance()->selectOne($c);
 		if($mem){
 			$runData->ajaxResponseAdd("status", "user_member");
-			$runData->ajaxResponseAdd("message", _("The user you want to block is a member of this site. Please first remove him/her from the site members list."));
+			$runData->ajaxResponseAdd("message", _("The user you want to block is a member of this site. Please first remove them from the site members list."));
 			return;
 		}
 

--- a/php/actions/ManageSiteMembershipAction.php
+++ b/php/actions/ManageSiteMembershipAction.php
@@ -595,7 +595,7 @@ class ManageSiteMembershipAction extends SmartyAction {
 			$c->setExplicitQuery($q);
 			$m = MemberPeer::instance()->selectOne($c);
 			if($m){
-				throw new ProcessException(sprintf(_('User with the email address "%s" is already a member of this Site. Remove him from the list and send invitations again.'), htmlspecialchars($email)), 'aleady_member');
+				throw new ProcessException(sprintf(_('User with the email address "%s" is already a member of this Site. Remove them from the list and send invitations again.'), htmlspecialchars($email)), 'aleady_member');
 			}
 
 			// check if not sent already to this address.
@@ -605,7 +605,7 @@ class ManageSiteMembershipAction extends SmartyAction {
 			$ii = EmailInvitationPeer::instance()->selectOne($c);
 
 			if($ii){
-				throw new ProcessException(sprintf(_('User with the email address "%s" has been already invited to this Site. Remove him from the list and send invitations again. If you want to resend an invitation please rather look at the history of sent invitations.'), htmlspecialchars($email)), 'aleady_member');
+				throw new ProcessException(sprintf(_('User with the email address "%s" has been already invited to this Site. Remove them from the list and send invitations again. If you want to resend an invitation please rather look at the history of sent invitations.'), htmlspecialchars($email)), 'aleady_member');
 			}
 		}
 

--- a/php/actions/wiki/UserInvitationAction.php
+++ b/php/actions/wiki/UserInvitationAction.php
@@ -83,7 +83,7 @@ class UserInvitationAction extends SmartyAction {
 			$c->setExplicitQuery($q);
 			$m = MemberPeer::instance()->selectOne($c);
 			if($m){
-				throw new ProcessException(sprintf(_('User with the email address "%s" is already a member of this Site. Remove him from the list and send invitations again.'), htmlspecialchars($email)), 'aleady_member');
+				throw new ProcessException(sprintf(_('User with the email address "%s" is already a member of this Site. Remove them from the list and send invitations again.'), htmlspecialchars($email)), 'aleady_member');
 			}
 
 			// check if not sent already to this address.
@@ -93,7 +93,7 @@ class UserInvitationAction extends SmartyAction {
 			$ii = EmailInvitationPeer::instance()->selectOne($c);
 
 			if($ii){
-				throw new ProcessException(sprintf(_('User with the email address "%s" has been already invited to this Site. Remove him from the list and send invitations again. If you want to resend an invitation please rather look at the history of sent invitations.'), htmlspecialchars($email)), 'aleady_member');
+				throw new ProcessException(sprintf(_('User with the email address "%s" has been already invited to this Site. Remove them from the list and send invitations again. If you want to resend an invitation please rather look at the history of sent invitations.'), htmlspecialchars($email)), 'aleady_member');
 			}
 		}
 

--- a/templates/emails/ChangeEmailVerification.tpl
+++ b/templates/emails/ChangeEmailVerification.tpl
@@ -11,7 +11,7 @@ Best regards - {$SERVICE_NAME}
 
 If you have NOT attempted to change your email address associated with
 a Wikidot account or even are not a service user it is possible
-that you have reveived this email because someone else mistyped her/his
+that you have reveived this email because someone else mistyped their
 own email address. If you however suspect any abuse, please contact
 
 

--- a/templates/emails/RegistrationEmailVerification.tpl
+++ b/templates/emails/RegistrationEmailVerification.tpl
@@ -16,6 +16,6 @@ Best regards - {$SERVICE_NAME}
 
 If you have NOT attempted to create an account at any of the {$SERVICE NAME}
 sites please ignore this email - it might have been sent because someone
-mistyped his/her own email address. If you however suspect any abuse,
+mistyped their own email address. If you however suspect any abuse,
 please contact our staff at {$HTTP_SCHEMA}://{$URL_HOST} or send
 an email to {$SUPPORT_EMAIL}

--- a/templates/modules/account/profile/ChangeScreenNameModule.tpl
+++ b/templates/modules/account/profile/ChangeScreenNameModule.tpl
@@ -4,7 +4,7 @@
 	Your current screen name is <strong>{$user->getNickName()|escape}</strong>.
 </p>
 <p>
-	Each Wikidot User can change his/her screen name <strong>twice</strong>. 
+	Each Wikidot User can change their screen name <strong>twice</strong>. 
 	It looks like you have changed yours <strong style="font-size:120%">{$profile->getChangeScreenNameCount()}</strong> time(s).
 </p>
 <p>

--- a/templates/modules/managesite/ManageSiteMembersListModule.tpl
+++ b/templates/modules/managesite/ManageSiteMembersListModule.tpl
@@ -27,7 +27,7 @@
 		Are you sure you want to remove user <b>%%USER_NAME%%</b> from the members?
 	</p>
 	<p>
-		If the user is also an administrator/moderator of this site his privileges will be lost too.
+		If the user is also an administrator/moderator of this site their privileges will be lost too.
 	</p>
 </div>
 <div style="display: none" id="remove-ban-user-dialog">
@@ -37,6 +37,6 @@
 		ban from accessing the site in the future?
 	</p>
 	<p>
-		If the user is also an administrator/moderator of this site his privileges will be lost too.
+		If the user is also an administrator/moderator of this site their privileges will be lost too.
 	</p>
 </div>

--- a/templates/modules/managesite/abuse/ManageSiteUserAbuseModule.tpl
+++ b/templates/modules/managesite/abuse/ManageSiteUserAbuseModule.tpl
@@ -44,7 +44,7 @@
 		Are you sure you want to remove user <b>%%USER_NAME%%</b> from the members?
 	</p>
 	<p>
-		If the user is also an administrator/moderator of this site his/her privileges will be lost too.
+		If the user is also an administrator/moderator of this site their privileges will be lost too.
 	</p>
 </div>
 <div style="display: none" id="remove-ban-user-dialog">
@@ -54,7 +54,7 @@
 		ban from accessing the site in the future?
 	</p>
 	<p>
-		If the user is also an administrator/moderator of this site his/her privileges will be lost too.
+		If the user is also an administrator/moderator of this site their privileges will be lost too.
 	</p>
 </div>
 <div style="display: none" id="ban-user-dialog">

--- a/templates/modules/membership/MembershipEmailInvitationModule.tpl
+++ b/templates/modules/membership/MembershipEmailInvitationModule.tpl
@@ -11,7 +11,7 @@
 		
 		<p>
 			It seems you got an invitation from our user {printuser user=$sender image=true} to become
-			a member of his/her Wiki Website <b>{$site->getName()|escape}</b> at <a href="{$HTTP_SCHEMA}://{$site->getDomain()}" target="_blank">{$HTTP_SCHEMA}://{$site->getDomain()}</a>.
+			a member of their Wiki Website <b>{$site->getName()|escape}</b> at <a href="{$HTTP_SCHEMA}://{$site->getDomain()}" target="_blank">{$HTTP_SCHEMA}://{$site->getDomain()}</a>.
 		</p>
 		<p>
 			All you have to do is to accept the invitation and we will instantly add you to members of this Site.

--- a/templates/modules/report/FlagAnonymousModule.tpl
+++ b/templates/modules/report/FlagAnonymousModule.tpl
@@ -21,8 +21,8 @@
 		violates Wikidot.com 
 		<a href="{$HTTP_SCHEMA}://{$URL_HOST}/legal:terms-of-service" target="_blank">Terms of Service</a>
 		of {$SERVICE_NAME},
-		posts objectionable content, may offend by his/her actions etc., you can
-		flag him/her as abusive. 
+		posts objectionable content, may offend by their actions etc., you can
+		flag them as abusive. 
 	</p>
 	<p>
 		No user will be automatically blocked, banned nor removed but the responsible authorities will

--- a/templates/modules/report/FlagUserModule.tpl
+++ b/templates/modules/report/FlagUserModule.tpl
@@ -7,8 +7,8 @@
 		If you think this user violates
 		<a href="{$HTTP_SCHEMA}://{$URL_HOST}/legal:terms-of-service" target="_blank">Terms of Service</a>
 		of {$SERVICE_NAME},
-		posts objectionable content, may offend by his/her actions etc., you can
-		flag him/her as abusive. 
+		posts objectionable content, may offend by their actions etc., you can
+		flag them as abusive. 
 	</p>
 	<p>
 		No user will be automatically blocked, banned nor removed but the responsible authorities will

--- a/web/files--common/modules/js/managesite/ManageSiteEmailInvitationsModule.js
+++ b/web/files--common/modules/js/managesite/ManageSiteEmailInvitationsModule.js
@@ -62,7 +62,7 @@ WIKIDOT.modules.ManageSiteEmailInvitationsModule.listeners = {
 		
 		if(adrs.length==0){
 			var w = new OZONE.dialogs.ErrorDialog();
-			w.content = "No valid recepients have been given. For each person both the email address and his/her name should be given.";
+			w.content = "No valid recepients have been given. For each person both the email address and name should be given.";
 			w.show();
 			return;
 		

--- a/web/files--common/modules/js/wiki/invitations/InviteMembersModule.js
+++ b/web/files--common/modules/js/wiki/invitations/InviteMembersModule.js
@@ -62,7 +62,7 @@ WIKIDOT.modules.InviteMembersModule.listeners = {
 		
 		if(adrs.length==0){
 			var w = new OZONE.dialogs.ErrorDialog();
-			w.content = "No valid recepients have been given. For each person both the email address and his/her name should be given.";
+			w.content = "No valid recepients have been given. For each person both the email address and name should be given.";
 			w.show();
 			return;
 		


### PR DESCRIPTION
There was a lot of 'his/her' and also a fair amount of just 'him'. They're now all 'they' et al.

`ag "\b(his|her|him|he|she)\b" --ignore-dir lib` now returns nothing.